### PR TITLE
Fix: reveal info pending section

### DIFF
--- a/batch-nft-reveal/app/components/collection/reveal-info/Revealinfo.tsx
+++ b/batch-nft-reveal/app/components/collection/reveal-info/Revealinfo.tsx
@@ -10,7 +10,7 @@ export const RevealInfo = (props: AddressProp): JSX.Element => {
 
   const nextRevealBatchSize = useNextRevealAmount(contractAddress)
   const nextRevealTime = useNextRevealTime(contractAddress)
-  const isPending = useContractCall('isPending', [], contractAddress)
+  const isPending = useContractCall('pendingReveal', [], contractAddress)
 
   return (
     <Container mt={5} maxWidth="100%" textAlign="center">


### PR DESCRIPTION
The section which shows if revealing is pending stopped working after isPending's method name in the contract was changed. 