### PR TITLE
fix: reveal info use checkUpkeep

### DIFF
--- a/batch-nft-reveal/app/components/collection/reveal-info/Revealinfo.tsx
+++ b/batch-nft-reveal/app/components/collection/reveal-info/Revealinfo.tsx
@@ -1,4 +1,5 @@
 import { Container, Heading } from '@chakra-ui/react'
+import { ethers } from 'ethers'
 import { useContractCall } from '../../../hooks/useContractCall'
 import { useNextRevealAmount } from '../../../hooks/useNextRevealAmount'
 import { useNextRevealTime } from '../../../hooks/useNextRevealTime'
@@ -10,12 +11,16 @@ export const RevealInfo = (props: AddressProp): JSX.Element => {
 
   const nextRevealBatchSize = useNextRevealAmount(contractAddress)
   const nextRevealTime = useNextRevealTime(contractAddress)
-  const isPending = useContractCall('pendingReveal', [], contractAddress)
+  const checkUpkeep = useContractCall(
+    'checkUpkeep',
+    [ethers.constants.HashZero],
+    contractAddress
+  )
 
   return (
     <Container maxWidth="100%" textAlign="center">
-      {isPending ? (
-        <Heading>Pending</Heading>
+      {checkUpkeep ? (
+        <Heading>Pending batch reveal</Heading>
       ) : (
         <>
           <Heading>Next reveal after</Heading>


### PR DESCRIPTION
Use checkUpkeep so RevealInfo's text is switched to Pending instantly instead of waiting for the keeper to update state variable

possible bug(?) : Sometimes the screen was flashing for a couple of frames and it changed some of the NFT's pictures to their unrevealed picture. This behavior was only possible when I was connected to metamask. When I was in incognito mode I couldn't repeat this behavior. 

It could be something on my end. 