### PR TITLE
fix: remove waiting 0 blocks when deploying contract

### DIFF
--- a/batch-nft-reveal/app/pages/create.tsx
+++ b/batch-nft-reveal/app/pages/create.tsx
@@ -34,7 +34,7 @@ function CreatePage(): JSX.Element {
           library?.getSigner(),
           chainId
         )
-        tx = await contract.deployTransaction.wait(0)
+        tx = await contract.deployTransaction.wait()
       } catch (ex) {
         ex.message ? setError(ex.message) : setError('Unsuccessful deployment')
         setIsLoading(false)


### PR DESCRIPTION
Changes from waiting 0 blocks to waiting until that tx is mined in a block. 