### PR TITLE
fix: add CNAME file automatically

### DIFF
--- a/.bin/deploy
+++ b/.bin/deploy
@@ -34,7 +34,7 @@ cd "$build_dir"
 touch .nojekyll
 
 # create CNAME if $domain is set
-[ -z "${domain}" ] && echo -n "$domain" > CNAME
+["${domain}"] && echo -n "$domain" > CNAME
 echo "[![Deploy to GitHub Pages](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/gh-pages.yml)" > README.md
 
 git add .


### PR DESCRIPTION
Changelog:

removes -z string comparison operator that checks if the string's length is 0 or is undefined. 